### PR TITLE
application_id & skip_provider_registration deprecated

### DIFF
--- a/terraform-example-deploy/main.tf
+++ b/terraform-example-deploy/main.tf
@@ -15,7 +15,7 @@ terraform {
 }
 
 provider "azurerm" {
-  skip_provider_registration = true
+  resource_provider_registrations = "none"
   features {}
 }
 

--- a/terraform-oidc-config/app_registration.tf
+++ b/terraform-oidc-config/app_registration.tf
@@ -12,16 +12,16 @@ resource "azuread_application" "github_oidc" {
 }
 
 resource "azuread_service_principal" "github_oidc" {
-  for_each       = local.app_registration_environments
-  application_id = azuread_application.github_oidc[each.value].application_id
+  for_each  = local.app_registration_environments
+  client_id = azuread_application.github_oidc[each.value].client_id
 }
 
 resource "azuread_application_federated_identity_credential" "github_oidc" {
-  for_each              = local.app_registration_environments
-  application_object_id = azuread_application.github_oidc[each.value].object_id
-  display_name          = "${var.azure_devops_organisation_target}-${var.azure_devops_project_target}-${each.value}"
-  description           = "Deployments for ${var.azure_devops_organisation_target}/${var.azure_devops_project_target} for environment ${each.value}"
-  audiences             = [local.default_audience_name]
-  issuer                = azuredevops_serviceendpoint_azurerm.oidc[each.key].workload_identity_federation_issuer
-  subject               = azuredevops_serviceendpoint_azurerm.oidc[each.key].workload_identity_federation_subject
+  for_each       = local.app_registration_environments
+  application_id = "/applications/${azuread_application.github_oidc[each.value].object_id}"
+  display_name   = "${var.azure_devops_organisation_target}-${var.azure_devops_project_target}-${each.value}"
+  description    = "Deployments for ${var.azure_devops_organisation_target}/${var.azure_devops_project_target} for environment ${each.value}"
+  audiences      = [local.default_audience_name]
+  issuer         = azuredevops_serviceendpoint_azurerm.oidc[each.key].workload_identity_federation_issuer
+  subject        = azuredevops_serviceendpoint_azurerm.oidc[each.key].workload_identity_federation_subject
 }

--- a/terraform-oidc-config/azure_devops_service_connections.tf
+++ b/terraform-oidc-config/azure_devops_service_connections.tf
@@ -5,7 +5,7 @@ resource "azuredevops_serviceendpoint_azurerm" "oidc" {
   description                            = "Managed by Terraform"
   service_endpoint_authentication_scheme = "WorkloadIdentityFederation"
   credentials {
-    serviceprincipalid = local.security_option.oidc_with_app_registration ? azuread_application.github_oidc[each.value].application_id : azurerm_user_assigned_identity.example[each.value].client_id
+    serviceprincipalid = local.security_option.oidc_with_app_registration ? azuread_application.github_oidc[each.value].client_id : azurerm_user_assigned_identity.example[each.value].client_id
   }
   azurerm_spn_tenantid      = data.azurerm_client_config.current.tenant_id
   azurerm_subscription_id   = data.azurerm_client_config.current.subscription_id

--- a/terraform-oidc-config/outputs.tf
+++ b/terraform-oidc-config/outputs.tf
@@ -11,5 +11,5 @@ output "tenant_id" {
 }
 
 output "service_principal_client_ids" {
-  value = local.security_option.oidc_with_app_registration ? { for env in var.environments : env => azuread_application.github_oidc[env].application_id } : { for env in var.environments : env => azurerm_user_assigned_identity.example[env].client_id }
+  value = local.security_option.oidc_with_app_registration ? { for env in var.environments : env => azuread_application.github_oidc[env].client_id } : { for env in var.environments : env => azurerm_user_assigned_identity.example[env].client_id }
 }


### PR DESCRIPTION
## Purpose
* switch to resource_provider_registrations = "none" as skip_provider_registration is deprecated in latest azurerm provider
* switch to client_id as application_id is deprecated in latest azuread provider

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
- install latest terraform 
- follow README.md steps

## What to Check
Verify that the following are valid
* creates expected resources

## Other Information